### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "flashsdk", ">= 1.0.0.pre"
-gem "sprout", ">= 1.1.19.pre"
+gem "sprout", ">= 1.1.18.pre"
+gem "iconv", "~> 1.0.3"
 gem "rake"


### PR DESCRIPTION
Fixed the Gemfile as the default gem file wasn't working because there is no sprout version 1.1.19.pre and
then the rake task wouldn't work because there was no iconv library installed.

On top of that, rubygems recommends to always use https.
